### PR TITLE
Remove link to porn

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ By [allenlsy](mailto:cafe@allenlsy.com)
 
 __Jekyll-galleries__ is a Jekyll plugin used for generating photo galleries from image folders.
 
-A demo to this plugin is on my [personal website](http://allenlsy.com/galleries).
-
 If you have any questions or any suggestions, I'm very pleased to hear from you. I need your support and ideas to make this plugin better.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jekyll-galleries
 
-By [allenlsy](mailto:cafe@allenlsy.com)
+By allenlsy
 
 __Jekyll-galleries__ is a Jekyll plugin used for generating photo galleries from image folders.
 


### PR DESCRIPTION
The demo address leads to a page with tons of japanese porn ads. Technically they ARE pictures but I doubt that they're using your Jekyll plugin :D